### PR TITLE
Made showHints work for lots of windows.

### DIFF
--- a/meat/osx/.phoenix.js
+++ b/meat/osx/.phoenix.js
@@ -222,9 +222,7 @@ function showHints (windows, prefix) {
 
   if (windows.length > HINT_CHARS.length) {
     var partitionSize = Math.floor(windows.length / HINT_CHARS.length);
-    var lists = _.toArray(_.groupBy(windows, function (win, k) {
-      return k % HINT_CHARS.length;
-    }));
+    let lists = Object.values(windows.reduce((acc, curVal, curIdx, arr, k = curIdx % HINT_CHARS.length) => ((acc[k] || acc[k] = []).push(curVal), acc), {}));
     for (var j = 0; j < HINT_CHARS.length; j++) {
       showHints(lists[j], prefix + HINT_CHARS[j]);
     }


### PR DESCRIPTION
The function showHints relied on a feature of UnderscoreJS that apparently
LoDash doesn't support. (The callback for groupBy assumed that the index of
the current element would be passed as its second argument.  Underscore does
this, but LoDash apparently does not.)

I'm not a great JS programmer. I ended up changing the partitioning to use
JavaScript's built-in Array.reduce and Object.values functions instead of
UnderscoreJS's (now LoDash's) _.groupBy and _.toArray.